### PR TITLE
use a single HTTP request to save order of documents

### DIFF
--- a/src/components/OrderDocuments.jsx
+++ b/src/components/OrderDocuments.jsx
@@ -182,12 +182,11 @@ Override existing data? This is a one-time operation and cannot be reversed.`
         ],
       }),
     });
-
-    await Promise.all([
-      setOrder(card1._id, afterIndex, this.state.field.value),
-      setOrder(card2._id, beforeIndex, this.state.field.value),
-    ]);
   };
+
+  onDragEnd = async () => {
+    await setListOrder(this.state.documents, this.state.field.value);
+  }
 
   render() {
     return (
@@ -206,6 +205,7 @@ Override existing data? This is a one-time operation and cannot be reversed.`
                 count={this.state.count}
                 type={this.state.type}
                 moveCard={this.moveCard}
+                onDragEnd={this.onDragEnd}
                 refreshDocuments={this.refreshDocuments}
                 loadMore={this.loadMore}
               />

--- a/src/components/molecules/Card.jsx
+++ b/src/components/molecules/Card.jsx
@@ -14,7 +14,7 @@ const style = {
   alignItems: "center",
 };
 
-export const Card = ({ id, index, moveCard, jsx }) => {
+export const Card = ({ id, index, moveCard, onDragEnd, jsx }) => {
   const ref = useRef(null);
 
   const [{ handlerId }, drop] = useDrop({
@@ -81,6 +81,9 @@ export const Card = ({ id, index, moveCard, jsx }) => {
     collect: (monitor) => ({
       isDragging: monitor.isDragging(),
     }),
+    end: () => {
+      onDragEnd()
+    }
   });
 
   const opacity = isDragging ? 0 : 1;

--- a/src/components/organisms/DraggableSection.jsx
+++ b/src/components/organisms/DraggableSection.jsx
@@ -8,7 +8,7 @@ import RefreshIcon from "../atoms/RefreshIcon";
 
 class DraggableSection extends React.Component {
   render() {
-    const { documents, count, type, moveCard, refreshDocuments, loadMore } = this.props;
+    const { documents, count, type, moveCard, onDragEnd, refreshDocuments, loadMore } = this.props;
 
     if (!(type && type.value) && !documents.length) {
       return null;
@@ -44,6 +44,7 @@ class DraggableSection extends React.Component {
                 id={document._id}
                 text={document.title}
                 moveCard={moveCard}
+                onDragEnd={onDragEnd}
                 jsx={<Preview value={document} type={schema.get(document._type)} />}
               />
             </li>

--- a/src/functions/setOrder.js
+++ b/src/functions/setOrder.js
@@ -12,9 +12,9 @@ export const setOrder = async (_id, index, field = DEFAULT_FIELD_VALUE) => {
 };
 
 export const setListOrder = async (list, field = DEFAULT_FIELD_VALUE, start = 0) => {
-  return Promise.all(
-    list.map(({ _id }, index) => {
-      return setOrder(_id, index + start, field);
-    })
-  );
+  const transaction = list.reduce((trx, {_id}, index) => {
+    return trx.patch(client.patch(_id).set({ [field]: index + start }));
+  }, client.transaction())
+
+  return transaction.commit();
 };


### PR DESCRIPTION
I noticed that when a document is reordered the plugin will fire off one POST request per document. In production I've noticed that these requests often do not all complete before the user leaves the page. This PR fixes that by using a single request to save the position of all the documents.

Also, rather than saving the order as the document is being dragged, it waits until the document is dropped into position before sending the POST request.